### PR TITLE
fix: adjust hamburger position

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -52,7 +52,7 @@ import {Image} from "astro:assets"
     --menu-height: 190px;
     --foreground: #333;
     --background: white;
-    --hamburger-margin: 24px;
+    --hamburger-margin: 38px;
     --animation-timing: 250ms ease-in-out;
     --hamburger-height: calc(var(--bar-height) * 3 + var(--hamburger-gap) * 2)
 


### PR DESCRIPTION
The old margin made the hamburger menu a bit off-center on mobile